### PR TITLE
Add magic_load_buffers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,4 +16,5 @@ extern "C" {
     pub fn magic_compile(cookie: *const Magic, filename: *const c_char) -> c_int;
     pub fn magic_list(cookie: *const Magic, filename: *const c_char) -> c_int;
     pub fn magic_load(cookie: *const Magic, filename: *const c_char) -> c_int;
+    pub fn magic_load_buffers(cookie: *const Magic, buffers: *const *const u8, sizes: *const size_t, nbuffers: size_t) -> c_int;
 }


### PR DESCRIPTION
Add a missing `magic_load_buffers` (load magic databases from memory) declaration as a prerequisite for a [rust-magic](https://github.com/robo9k/rust-magic) PR.