### PR TITLE
Allow overriding the link search path with `<TARGET>_MAGIC_DIR`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,49 @@
+fn env(name: &str) -> Option<std::ffi::OsString> {
+    let target = std::env::var("TARGET").expect("Cargo didn't provide `TARGET` environment var");
+    let target = target.to_uppercase().replace("-", "_");
+    let prefixed_name = format!("{}_{}", target, name);
+    println!("cargo:rerun-if-env-changed={}", prefixed_name);
+    match std::env::var_os(prefixed_name) {
+        Some(v) => Some(v),
+        None => {
+            println!("cargo:rerun-if-env-changed={}", name);
+            std::env::var_os(name)
+        }
+    }
+}
+
 fn main() {
-    println!("cargo:rustc-flags=-l magic");
+    if let Some(magic_dir) = env("MAGIC_DIR").map(std::path::PathBuf::from) {
+        if !std::path::Path::new(&magic_dir).exists() {
+            panic!("Magic library directory {:?} does not exist", magic_dir);
+        }
+        println!("cargo:rustc-link-search=native={}", magic_dir.to_string_lossy());
+
+        let static_lib = magic_dir.join("libmagic.a");
+        let shared_lib = magic_dir.join("libmagic.so");
+        match env("MAGIC_STATIC").as_ref().and_then(|s| s.to_str()) {
+            Some("false") | Some("FALSE") | Some("0") => {
+                if !shared_lib.exists() {
+                    panic!("No libmagic.so found in {:?}", magic_dir);
+                }
+                println!("cargo:rustc-link-lib=dylib=magic");
+            }
+            Some(_) => {
+                if !static_lib.exists() {
+                    panic!("No libmagic.a found in {:?}", magic_dir);
+                }
+                println!("cargo:rustc-link-lib=static=magic");
+            }
+            None => {
+                match (static_lib.exists(), shared_lib.exists()) {
+                    (false, false) => panic!("Neither libmagic.so, nor libmagic.a was found in {:?}", magic_dir),
+                    (true, false) => println!("cargo:rustc-link-lib=static=magic"),
+                    (false, true) => println!("cargo:rustc-link-lib=dylib=magic"),
+                    (true, true) => panic!("Both a static and a shared library were found in {:?}\nspecify a choice with `MAGIC_STATIC=true|false`", magic_dir),
+                }
+            }
+        }
+    } else {
+        println!("cargo:rustc-link-lib=dylib=magic");
+    }
 }


### PR DESCRIPTION
In a way similar to `openssl-sys` this allows the user to pass a `MAGIC_DIR` environment variable that tells rustc where to find `libmagic.so/libmagic.a`.  For finer grained control, the user can pass an environment variable like `x86_64_UNKNOWN_LINUX_MUSL_MAGIC_DIR` to only set the custom search path for a specific target.

Static linking is also now possible, detected either by only a `libmagic.a` found in the (provided) search path, or by explicitly passing `MAGIC_STATIC=true` (or `<TARGET>_MAGIC_STATIC=true`).  Similarly `MAGIC_STATIC=false` can be passed to choose to link dynamically.  If neither is passed, but both libraries are available, the `build.rs` bails out and asks the user to choose an implementation, an alternative would be to pick one (`openssl-sys` picks "shared library" in this case).

Tested with a local, static-only, `musl-gcc`-compiled libmagic:

```
$ X86_64_UNKNOWN_LINUX_MUSL_MAGIC_STATIC=true X86_64_UNKNOWN_LINUX_MUSL_MAGIC_DIR=../libmagic/src/.libs cargo c -vv --target x86_64-unknown-linux-musl
...
     Running `/home/andy/src/rust-magic-sys/target/debug/build/magic-sys-3a925b5dcd0ba125/build-script-build`
[magic-sys 0.2.0] cargo:rerun-if-env-changed=X86_64_UNKNOWN_LINUX_MUSL_MAGIC_DIR
[magic-sys 0.2.0] cargo:rustc-link-search=native=../libmagic/src/.libs
[magic-sys 0.2.0] cargo:rerun-if-env-changed=X86_64_UNKNOWN_LINUX_MUSL_MAGIC_STATIC
[magic-sys 0.2.0] cargo:rustc-link-lib=static=magic
     Running `CARGO=/home/andy/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/cargo CARGO_MANIFEST_DIR=/home/andy/src/rust-magic-sys CARGO_PKG_AUTHORS='robo9k <robo@9k.lv>' CARGO_PKG_DESCRIPTION='Declarations for `libmagic`' CARGO_PKG_HOMEPAGE='https://github.com/robo9k/rust-magic-sys' CARGO_PKG_NAME=magic-sys CARGO_PKG_REPOSITORY='https://github.com/robo9k/rust-magic-sys.git' CARGO_PKG_VERSION=0.2.0 CARGO_PKG_VERSION_MAJOR=0 CARGO_PKG_VERSION_MINOR=2 CARGO_PKG_VERSION_PATCH=0 CARGO_PKG_VERSION_PRE= LD_LIBRARY_PATH='/home/andy/src/rust-magic-sys/target/debug/deps:/home/andy/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib:/home/andy/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib' OUT_DIR=/home/andy/src/rust-magic-sys/target/x86_64-unknown-linux-musl/debug/build/magic-sys-e078dc43334cb961/out sccache-msw rustc --crate-name magic_sys src/lib.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type lib --emit=dep-info,metadata -Cembed-bitcode=no -C debuginfo=2 -C metadata=2a7a520a13672ee4 -C extra-filename=-2a7a520a13672ee4 --out-dir /home/andy/src/rust-magic-sys/target/x86_64-unknown-linux-musl/debug/deps --target x86_64-unknown-linux-musl -C incremental=/home/andy/src/rust-magic-sys/target/x86_64-unknown-linux-musl/debug/incremental -L dependency=/home/andy/src/rust-magic-sys/target/x86_64-unknown-linux-musl/debug/deps -L dependency=/home/andy/src/rust-magic-sys/target/debug/deps --extern libc=/home/andy/src/rust-magic-sys/target/x86_64-unknown-linux-musl/debug/deps/liblibc-df81d5c25afc76a4.rmeta -L native=../libmagic/src/.libs -l static=magic`
    Finished dev [unoptimized + debuginfo] target(s) in 0.92s
```

If neither environment variable is set, the behaviour is completely unchanged (we link dynamically with the system-wide library).