### PR TITLE
Determine and document minimum supported rust version (MSRV)

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: vcpkg
       run: |
-        cargo install cargo-vcpkg
+        cargo +stable install cargo-vcpkg
         cargo vcpkg build
     - name: Build
       run: cargo build --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ exclude = [
     ".gitignore",
     "/.github/",
 ]
+rust-version = "1.38"
 
 [dependencies]
 libc = "0.2.13"
@@ -31,3 +32,6 @@ dependencies = ["libmagic"]
 
 [package.metadata.vcpkg.target]
 x86_64-pc-windows-msvc = { triplet="x64-windows-static-md" }
+
+[package.metadata]
+msrv = "1.38.0"

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ cargo vcpkg build
 ```
 Afterwards, you can `cargo build` etc. your crate as usual.
 
+# MSRV
+
+The Minimum Supported Rust Version (MSRV) is Rust 1.38 or higher.
+
+This version might be changed in the future, but it will be done with a crate version bump.
+
 # Building
 
 By default `libmagic` will be searched in the system library paths. If you need to use a different library or are cross-compiling, you can set the `MAGIC_DIR` and `MAGIC_STATIC` environment variables.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.38.0"


### PR DESCRIPTION
This was done using `cargo msrv` with `cargo test` on Linux.

CI has not been adjusted to have a build matrix for MSRV. MSRV and current stable should be built for all platforms in a future merge request.