### PR TITLE
Limit `cargo deny` to relevant file paths

### DIFF
--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -3,8 +3,16 @@ name: cargo deny
 on:
   push:
     branches: [ main ]
+    paths: 
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - '.github/workflows/deny.yml'
   pull_request:
     branches: [ main ]
+    paths: 
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - '.github/workflows/deny.yml'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
There's no need to run `cargo deny` when nothing changed.