### PR TITLE
Release candidate v0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = [
 ]
 repository = "https://github.com/robo9k/rust-magic-sys.git"
 license = "MIT/Apache-2.0"
-version = "0.2.1"
+version = "0.3.0-alpha.1"
 authors = ["robo9k <robo9k@symlink.io>"]
 links = "magic"
 exclude = [
@@ -47,10 +47,6 @@ v5-35 = ["v5-32"]
 v5-38 = ["v5-35"]
 v5-40 = ["v5-38"]
 
-[dependencies.libc]
-version = "0.2.104"
-default-features = false
-
 [build-dependencies]
 vcpkg = "0.2.15"
 
@@ -58,6 +54,10 @@ vcpkg = "0.2.15"
 git = "https://github.com/microsoft/vcpkg"
 rev = "078f3e5"
 dependencies = ["libmagic"]
+
+[dependencies.libc]
+version = "0.2.104"
+default-features = false
 
 [package.metadata.vcpkg.target]
 x86_64-pc-windows-msvc = { triplet = "x64-windows-static-md" }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This [cargo -sys package](https://doc.rust-lang.org/cargo/reference/build-script
 
 ```toml
 [dependencies]
-magic-sys = "0.2.0"
+magic-sys = "0.3"
 ```
 
 The `rustdoc` is available on [docs.rs](https://docs.rs/magic-sys).
@@ -28,7 +28,7 @@ Each API version has a crate feature like "v5-38" (v5.38 is also the default), s
 If you use a different version of `libmagic`, adjust your configuration:
 ```toml
 [dependencies.magic-sys]
-version = "0.2.1"
+version = "0.3"
 default-features = false
 features = ["v5-41"]
 ```


### PR DESCRIPTION
Changes to release next new version.

Due to #16 possibly breaking API if not using default features, this is new major semver