### PR TITLE
Fix return type of `magic_errno`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ extern "C" {
     #[cfg(feature = "v5-05")]
     #[must_use]
     pub fn magic_list(cookie: magic_t, filename: *const c_char) -> c_int;
-    pub fn magic_errno(cookie: magic_t) -> *const c_int;
+    pub fn magic_errno(cookie: magic_t) -> c_int;
 
     #[cfg(feature = "v5-21")]
     #[must_use]


### PR DESCRIPTION
The function definition from `magic.h` is:
```C
int magic_errno(magic_t);
```

This was just a copy & paste mistake. Probably does not require yanking faulty crate versions.