### PR TITLE
Make crate `#![no_std]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ keywords = [
 ]
 categories = [
     "external-ffi-bindings",
+    "no-std",
 ]
 repository = "https://github.com/robo9k/rust-magic-sys.git"
 license = "MIT/Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+// Technically this crate doesn't need Rust `std`
+// but you'll still have to get the `libmagic` C library working for your target
+#![cfg_attr(not(test), no_std)]
+
 extern crate libc;
 #[cfg(feature = "v5-20")]
 use libc::c_void;


### PR DESCRIPTION
Technically since this crate only contains code that works without `std`, it can be `no_std`.
Realistically those `no_std` targets are unlikely to support `libmagic` 🤷 

The `magic` crate uses e.g. `std::path::Path`, so it probably won't be able to make use of this.

No automated CI is added to ensure the crate remains `no_std` compatible.

This is a semver compatible change.