### PR TITLE
Bump MSRV to 1.54.0

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -20,6 +20,14 @@ jobs:
       run: |
         brew update
         brew install libmagic
+    - name: install Rust MSRV
+      uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
+      with:
+        profile: minimal
+        # toolchain could be implicit from rust-toolchain.toml see https://github.com/actions-rs/toolchain#the-toolchain-file
+        # but this doesn't support .toml files
+        toolchain: "1.64.0"
+        override: true
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ exclude = [
     "nix/",
     "deny.toml",
 ]
-rust-version = "1.38"
+rust-version = "1.54"
 
 [badges]
 maintenance = { status = "passively-maintained" }
@@ -64,7 +64,7 @@ default-features = false
 x86_64-pc-windows-msvc = { triplet = "x64-windows-static-md" }
 
 [package.metadata]
-msrv = "1.38.0"
+msrv = "1.54.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Afterwards, you can `cargo build` etc. your crate as usual.
 
 # MSRV
 
-The Minimum Supported Rust Version (MSRV) is Rust 1.38 or higher.
+The Minimum Supported Rust Version (MSRV) is Rust 1.54 or higher.
 
 This version might be changed in the future, but it will be done with a crate version bump.
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.38.0"
+channel = "1.54.0"


### PR DESCRIPTION
This should fix #32 

Requires publishing a new (minor) version, likely for the `magic` crate as well.