### PR TITLE
Use `pkg-config`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ v5-38 = ["v5-35"]
 v5-40 = ["v5-38"]
 
 [build-dependencies]
+pkg-config = "0.3.27"
 vcpkg = "0.2.15"
 
 [package.metadata.vcpkg]


### PR DESCRIPTION
This implements #1 and should solve the long standing issues of linking on macOS and statically in general.

This is a (potentially) breaking change for several reasons:
- `MAGIC_DIR`, `<TARGET>_MAGIC_DIR`, `MAGIC_STATIC`, `<TARGET>_MAGIC_STATIC` environment variables are no longer supported
users need to configure `pkg-config` or `vcpkg` instead
- `libmagic` needs to be version 5.39 or newer
this is required to have a `libmagic.pc` for `pkg-config`, see https://github.com/robo9k/rust-magic-sys/issues/1#issuecomment-947707426
- the old version feature flags `v5-38` and below no longer make sense and need to be removed, see https://github.com/robo9k/rust-magic-sys/issues/36#issuecomment-1745873239

Related issues:
- #35 looks at how GitHub Actions could work with those new requirements
This pull request here does not update the workflows yet
- #36 looks at the results of the changed crate requirements
Ubuntu 20.04.6 LTS Focal Fossa is no longer supported with its default packages

Misc:
- the new `pkg-config` crate dependency has a MSRV of v1.30.0, so we don't need to bump ours

Follow-up tasks: (not in this pull request)
- [ ] Remove old `libmagic` version crate features
- [ ] Make both pkg-config and vcpkg into default-features
- [ ] CI workflows for supported configurations (e.g. Windows / Linux / macOS, static / dynamic, pkg-config / vcpkg)
- [ ] Document CI workflows so others can re-use them
- [ ] Release & publish new crate version
- [ ] Use new crate version in `magic` crate