### PR TITLE
Make `pkg-config` and `vcpkg` default crate features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ rust-version = "1.54"
 maintenance = { status = "passively-maintained" }
 
 [features]
-default = ["v5-38"]
+default = ["v5-38", "pkg-config", "vcpkg"]
 v5-04 = []
 v5-05 = ["v5-04"]
 v5-10 = ["v5-05"]
@@ -49,8 +49,8 @@ v5-38 = ["v5-35"]
 v5-40 = ["v5-38"]
 
 [build-dependencies]
-pkg-config = "0.3.27"
-vcpkg = "0.2.15"
+pkg-config = { version = "0.3.27", optional = true }
+vcpkg = { version = "0.2.15", optional = true }
 
 [package.metadata.vcpkg]
 git = "https://github.com/microsoft/vcpkg"

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ To determine which `libmagic` to link against, this crate uses
 [`pkg-config`](https://www.freedesktop.org/wiki/Software/pkg-config/)
 and [`vcpkg`](https://vcpkg.io/).
 
+The crate does not offer to link a against a bundled `libmagic` version, see [issue #4](https://github.com/robo9k/rust-magic-sys/issues/4).
+
 In general you can link statically or dynamically against `libmagic`.
 
 With static linkage your binary/library includes the `libmagic` code and _does not_ have a run-time dependency.
@@ -90,7 +92,7 @@ You might want to ship a copy of the default `libmagic` / `file` database with y
 
 ## pkg-config
 
-This uses the [`pkg-config` crate](https://docs.rs/pkg-config), so check its documentation for details.
+The `pkg-config` crate feature uses the [`pkg-config` crate](https://docs.rs/pkg-config), so check its documentation for details.
 
 You can use e.g. the following environment variables:
 - `LIBMAGIC_NO_PKG_CONFIG` if set, will skip `pkg-config`
@@ -101,7 +103,7 @@ By default dynamic linkage is used.
 
 ## vcpkg
 
-This uses the [`vcpkg` crate](https://docs.rs/vcpkg), so check its documentation for details.
+The `vcpkg` crate feature uses the [`vcpkg` crate](https://docs.rs/vcpkg), so check its documentation for details.
 
 You can use e.g. the following environment variables:
 - `VCPKGRS_NO_LIBMAGIC` if set, will skip `vcpkg`
@@ -115,15 +117,13 @@ If you do _not_ use `cargo vcpkg build`, you will have to either
 - `vcpkg install libmagic` and set the `VCPKG_ROOT` environment variable for your `vcpkg` root directory
 - `vcpkg integrate install` your `vcpkg` root user-wide
 
-## Custom
+## Override
 
-If you skip both `pkg-config` and `vcpkg` the `magic-sys` build script will fail.\
+If you disable or skip both `pkg-config` and `vcpkg` the `magic-sys` build script will fail.\
 Especially linking statically to `libmagic` requires additional libraries that depend on your version and system.
 
 You can skip the `magic-sys` build script entirely by [overriding it](https://doc.rust-lang.org/cargo/reference/build-scripts.html#overriding-build-scripts).\
 This is an option if you want to use neither `pkg-config` nor `vcpkg`.
-
-The `magic-sys` crate does not offer to link a against a bundled `libmagic` version.
 
 # License
 

--- a/build.rs
+++ b/build.rs
@@ -1,41 +1,88 @@
 // SPDX-FileCopyrightText: © The `magic-sys` Rust crate authors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-fn main() {
+#[cfg(any(feature = "pkg-config", feature = "vcpkg"))]
+enum LibraryResult<E, L> {
+    Skipped(E),
+    Failed(E),
+    Success(L),
+}
+
+#[cfg(feature = "pkg-config")]
+fn try_pkgconfig() -> LibraryResult<pkg_config::Error, pkg_config::Library> {
     let lib = pkg_config::Config::new()
         .atleast_version("5.39")
         .probe("libmagic");
     match lib {
         Err(err) => match err {
-            pkg_config::Error::EnvNoPkgConfig(_) => {
-                println!("pkg-config skipped: {}", err);
-            }
-            _ => {
-                println!("cargo:warning=pkg-config failed: {}", err);
-            }
+            pkg_config::Error::EnvNoPkgConfig(_) => LibraryResult::Skipped(err),
+            _ => LibraryResult::Failed(err),
         },
-        Ok(lib) => {
-            println!("pkg-config success: {:?}", lib);
-            return;
-        }
+        Ok(lib) => LibraryResult::Success(lib),
     }
+}
 
+#[cfg(feature = "vcpkg")]
+fn try_vcpkg() -> LibraryResult<vcpkg::Error, vcpkg::Library> {
     let lib = vcpkg::find_package("libmagic");
     match lib {
         Err(err) => match err {
-            vcpkg::Error::DisabledByEnv(_) => {
-                println!("vcpkg skipped: {}", err);
-            }
-            _ => {
-                println!("cargo:warning=vcpkg failed: {}", err);
-            }
+            vcpkg::Error::DisabledByEnv(_) => LibraryResult::Skipped(err),
+            _ => LibraryResult::Failed(err),
         },
-        Ok(lib) => {
-            println!("vcpkg success: {:?}", lib);
-            return;
+        Ok(lib) => LibraryResult::Success(lib),
+    }
+}
+
+fn main() {
+    #[cfg(feature = "pkg-config")]
+    {
+        let lib = try_pkgconfig();
+        match lib {
+            LibraryResult::Skipped(err) => {
+                println!("pkg-config skipped: {}", err);
+            }
+            LibraryResult::Failed(err) => {
+                println!("cargo:warning=pkg-config failed: {}", err);
+            }
+            LibraryResult::Success(lib) => {
+                println!("pkg-config success: {:?}", lib);
+                return;
+            }
         }
     }
+    #[cfg(not(feature = "pkg-config"))]
+    println!("pkg-config feature disabled");
 
-    // if we're reach here, this means that either both pkg-config and vcpkg got skipped or both failed
-    panic!("could not link to `libmagic` with neither `pkg-config` nor `vcpkg`");
+    #[cfg(feature = "vcpkg")]
+    {
+        let lib = try_vcpkg();
+        match lib {
+            LibraryResult::Skipped(err) => {
+                println!("vcpkg skipped: {}", err);
+            }
+            LibraryResult::Failed(err) => {
+                println!("cargo:warning=vcpkg failed: {}", err);
+            }
+            LibraryResult::Success(lib) => {
+                println!("vcpkg success: {:?}", lib);
+                return;
+            }
+        }
+    }
+    #[cfg(not(feature = "vcpkg"))]
+    println!("vcpkg feature disabled");
+
+    // if we're reach here, this means that either both pkg-config and vcpkg
+    // got skipped or
+    // both failed or
+    // both features are disabled
+    #[cfg(not(any(feature = "pkg-config", feature = "vcpkg")))]
+    println!(
+        "the pkg-config and vcpkg features are both disabled, \
+        this configuration requires you to override the build script: \
+        https://crates.io/crates/magic#override"
+    );
+
+    panic!("could not link to `libmagic`");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,18 @@
+//! # Features
+//!
+//! This crate has the following [features](https://doc.rust-lang.org/cargo/reference/features.html#features):
+//!
+//! - `pkg-config`: Enables using [`pkg-config`](https://www.freedesktop.org/wiki/Software/pkg-config/)
+//! with the [`pkg-config` crate](https://docs.rs/pkg-config) in the build script\
+//! Check the [crate README](https://crates.io/crates/magic#pkg-config) for configuration details
+//! - `vcpkg`: Enables using [`vcpkg`](https://vcpkg.io/)
+//! with the [`vcpkg` crate](https://docs.rs/vcpkg) in the build script\
+//! Check the [crate README](https://crates.io/crates/magic#vcpkg) for configuration details
+//!
+//! The following features are enabled by default:
+//! - `pkg-config`
+//! - `vcpkg`
+
 // Technically this crate doesn't need Rust `std`
 // but you'll still have to get the `libmagic` C library working for your target
 #![cfg_attr(not(test), no_std)]


### PR DESCRIPTION
This makes both `pkg-config` and `vcpkg` optional build dependencies.

This allows to e.g. disable the default features and only use `vcpkg` on Windows-only builds.