### PR TITLE
Add and use `setup-libmagic` GitHub Action

### DIFF
--- a/.github/actions/setup-libmagic/action.yml
+++ b/.github/actions/setup-libmagic/action.yml
@@ -1,0 +1,87 @@
+name: setup-libmagic
+description: Setup some version of `libmagic` for `magic-sys`
+
+runs:
+  using: 'composite'
+  steps:
+    # setup cache
+    - name: setup cache
+      if: ${{ runner.os == 'Windows' }}
+      uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+      with:
+        script: |
+          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+
+    # update packages
+
+    - name: update packages
+      if: ${{ runner.os == 'Linux' }}
+      run: sudo apt-get update
+      shell: bash
+
+    - name: update packages
+      if: ${{ runner.os == 'Windows' }}
+      run: vcpkg update
+      shell: bash
+
+    - name: update packages
+      if: ${{ runner.os == 'macOS' }}
+      run: brew update
+      shell: bash
+
+
+    # install packages
+
+    - name: install packages
+      if: ${{ runner.os == 'Linux' }}
+      run: sudo apt-get install libmagic1 libmagic-dev pkg-config
+      shell: bash
+
+    - name: install packages
+      if: ${{ runner.os == 'Windows' }}
+      run: |
+        vcpkg install libmagic:x64-windows-static-md
+        echo "VCPKG_ROOT=${VCPKG_INSTALLATION_ROOT}" >> "${GITHUB_ENV}"
+      shell: bash
+
+    - name: install packages
+      if: ${{ runner.os == 'macOS' }}
+      run: brew install libmagic pkg-config
+      shell: bash
+
+
+    # setup environment
+
+    - name: setup environment
+      if: ${{ runner.os == 'Linux' }}
+      run: echo "VCPKGRS_NO_LIBMAGIC=1" >> "${GITHUB_ENV}"
+      shell: bash
+
+    - name: setup environment
+      if: ${{ runner.os == 'Windows' }}
+      run: echo "LIBMAGIC_NO_PKG_CONFIG=1" >> "${GITHUB_ENV}"
+      shell: bash
+
+    - name: setup environment
+      if: ${{ runner.os == 'macOS' }}
+      run: echo "VCPKGRS_NO_LIBMAGIC=1" >> "${GITHUB_ENV}"
+      shell: bash
+
+    # setup static build
+
+    - name: setup static build
+      if: ${{ runner.os == 'Linux' }}
+      run: echo "LIBMAGIC_STATIC=1" >> "${GITHUB_ENV}"
+      shell: bash
+
+    - name: setup static build
+      if: ${{ runner.os == 'Windows' }}
+      run: echo "Static builds are the default for vcpkg-rs"
+      shell: bash
+
+    - name: setup static build
+      if: ${{ runner.os == 'macOS' }}
+      run: echo "LIBMAGIC_STATIC=1" >> "${GITHUB_ENV}"
+      shell: bash

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -16,6 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - uses: ./.github/actions/setup-libmagic
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -16,10 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: brew
-      run: |
-        brew update
-        brew install libmagic
+    - uses: ./.github/actions/setup-libmagic
     - name: install Rust MSRV
       uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
       with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,10 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: vcpkg
-      run: |
-        cargo +stable install cargo-vcpkg
-        cargo vcpkg build
+    - uses: ./.github/actions/setup-libmagic
     - name: Build
       run: cargo build --verbose
     - name: Run tests


### PR DESCRIPTION
This is a reusable Action to setup some version of `libmagic` for use with this crate.
This is also the minimum that must pass CI for this project as it should be the most common use-case.

Other fancier extra build workflows from https://github.com/robo9k/rust-magic-sys/pull/39#issue-1931419619 can be added separately lateron.

If this Action works well here (and in [robo9k/rust-magic](https://github.com/robo9k/rust-magic)) it should be documented publically. Publishing to the Marketplace is not neccessary.