### PR TITLE
Link to `shlwapi` on Windows (again) as workaround

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -30,7 +30,12 @@ fn try_vcpkg() -> LibraryResult<vcpkg::Error, vcpkg::Library> {
             vcpkg::Error::DisabledByEnv(_) => LibraryResult::Skipped(err),
             _ => LibraryResult::Failed(err),
         },
-        Ok(lib) => LibraryResult::Success(lib),
+        Ok(lib) => {
+            // workaround, see https://github.com/robo9k/rust-magic-sys/pull/16#issuecomment-949094327
+            println!("cargo:rustc-link-lib=shlwapi");
+
+            LibraryResult::Success(lib)
+        }
     }
 }
 


### PR DESCRIPTION
Re-adds the workaround from https://github.com/robo9k/rust-magic-sys/pull/16#issuecomment-949094327 since that is still broken even in recent `vcpkg` port.