### PR TITLE
Run CI build workflow on default branch for caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@ name: "build"
 permissions: {}
 
 on:
+  # run on default branch to store caches
+  push:
+    branches: [ main ]
   pull_request:
 
 jobs:


### PR DESCRIPTION
Currently both the `Swatinem/rust-cache` and `vcpkg` cache can not be restored from the default branch since there are no builds for it, thus pull requests only use their own cache on rebuilds.