### PR TITLE
Build extra CI scenarios

### DIFF
--- a/.github/actions/setup-libmagic/action.yml
+++ b/.github/actions/setup-libmagic/action.yml
@@ -1,17 +1,87 @@
 name: setup-libmagic
 description: Setup some version of `libmagic` for `magic-sys`
+inputs:
+  linkage:
+    description: 'How to link (against `libmagic`): "static" / "dynamic"'
+    default: static
 
 runs:
   using: 'composite'
   steps:
-    # setup cache
-    - name: setup cache
+    # check inputs
+    - name: check inputs
+      run: |
+        if [[ ! ("${{ inputs.linkage }}" == "static" || "${{ inputs.linkage }}" == "dynamic") ]]; then
+          echo "'linkage' input must be either 'static' or 'dynamic' but it is: ${{ inputs.linkage }}"
+          exit 1
+        fi
+      shell: bash
+
+
+    # setup environment
+
+    - name: setup environment
+      if: ${{ runner.os == 'Linux' }}
+      run: echo "VCPKGRS_NO_LIBMAGIC=1" >> "${GITHUB_ENV}"
+      shell: bash
+
+    - name: setup environment
+      if: ${{ runner.os == 'Windows' }}
+      run: echo "LIBMAGIC_NO_PKG_CONFIG=1" >> "${GITHUB_ENV}"
+      shell: bash
+
+    - name: setup environment
+      if: ${{ runner.os == 'macOS' }}
+      run: echo "VCPKGRS_NO_LIBMAGIC=1" >> "${GITHUB_ENV}"
+      shell: bash
+
+
+    # setup linkage
+
+    - name: setup linkage
+      if: ${{ runner.os == 'Linux' }}
+      run: |
+        if [[ "${{ inputs.linkage }}" == "static" ]]; then
+          echo "LIBMAGIC_STATIC=1" >> "${GITHUB_ENV}"
+        elif [[ "${{ inputs.linkage }}" == "dynamic" ]]; then
+          echo "LIBMAGIC_DYNAMIC=1" >> "${GITHUB_ENV}"
+        fi
+      shell: bash
+
+    - name: setup linkage
+      if: ${{ runner.os == 'Windows' }}
+      run: |
+        if [[ "${{ inputs.linkage }}" == "static" ]]; then
+          echo "VCPKG_DEFAULT_TRIPLET=x64-windows-static-md" >> "${GITHUB_ENV}"
+        elif [[ "${{ inputs.linkage }}" == "dynamic" ]]; then
+          echo "VCPKG_DEFAULT_TRIPLET=x64-windows" >> "${GITHUB_ENV}"
+          echo "VCPKGRS_DYNAMIC=1" >> "${GITHUB_ENV}"
+        fi
+      shell: bash
+
+    - name: setup linkage
+      if: ${{ runner.os == 'macOS' }}
+      run: |
+        if [[ "${{ inputs.linkage }}" == "static" ]]; then
+          echo "LIBMAGIC_STATIC=1" >> "${GITHUB_ENV}"
+        elif [[ "${{ inputs.linkage }}" == "dynamic" ]]; then
+          echo "LIBMAGIC_DYNAMIC=1" >> "${GITHUB_ENV}"
+        fi
+      shell: bash
+
+
+    # vcpkg cache
+    - name: expose cache
       if: ${{ runner.os == 'Windows' }}
       uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
       with:
         script: |
           core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
           core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+    - name: setup cache
+      if: ${{ runner.os == 'Windows' }}
+      run: echo "VCPKG_BINARY_SOURCES=clear;x-gha,readwrite" >> "${GITHUB_ENV}"
+      shell: bash
 
 
     # update packages
@@ -42,46 +112,11 @@ runs:
     - name: install packages
       if: ${{ runner.os == 'Windows' }}
       run: |
-        vcpkg install libmagic:x64-windows-static-md
+        vcpkg install libmagic
         echo "VCPKG_ROOT=${VCPKG_INSTALLATION_ROOT}" >> "${GITHUB_ENV}"
       shell: bash
 
     - name: install packages
       if: ${{ runner.os == 'macOS' }}
       run: brew install libmagic pkg-config
-      shell: bash
-
-
-    # setup environment
-
-    - name: setup environment
-      if: ${{ runner.os == 'Linux' }}
-      run: echo "VCPKGRS_NO_LIBMAGIC=1" >> "${GITHUB_ENV}"
-      shell: bash
-
-    - name: setup environment
-      if: ${{ runner.os == 'Windows' }}
-      run: echo "LIBMAGIC_NO_PKG_CONFIG=1" >> "${GITHUB_ENV}"
-      shell: bash
-
-    - name: setup environment
-      if: ${{ runner.os == 'macOS' }}
-      run: echo "VCPKGRS_NO_LIBMAGIC=1" >> "${GITHUB_ENV}"
-      shell: bash
-
-    # setup static build
-
-    - name: setup static build
-      if: ${{ runner.os == 'Linux' }}
-      run: echo "LIBMAGIC_STATIC=1" >> "${GITHUB_ENV}"
-      shell: bash
-
-    - name: setup static build
-      if: ${{ runner.os == 'Windows' }}
-      run: echo "Static builds are the default for vcpkg-rs"
-      shell: bash
-
-    - name: setup static build
-      if: ${{ runner.os == 'macOS' }}
-      run: echo "LIBMAGIC_STATIC=1" >> "${GITHUB_ENV}"
       shell: bash

--- a/.github/workflows/build-extra.yml
+++ b/.github/workflows/build-extra.yml
@@ -1,0 +1,114 @@
+name: "build-extra"
+
+permissions: {}
+
+on:
+  # run on default branch to store caches
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build-extra:
+    name: "cargo build [dynamic]"
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        runner: [ubuntu-22.04, windows-2022, macos-12]
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: step-security/harden-runner@1b05615854632b887b69ae1be8cbefe72d3ae423 # v2.6.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+
+      - uses: ./.github/actions/setup-libmagic
+        with:
+          linkage: dynamic
+
+      - id: toolchain
+        uses: dtolnay/rust-toolchain@439cf607258077187679211f12aa6f19af4a0af7 # doesn't have usual versioned releases/tags
+        with:
+          toolchain: "1.54.0" # hardcoded crate MSRV, see rust-toolchain.toml etc.
+          # minimal profile includes rustc component which includes cargo and rustdoc
+
+      - uses: rui314/setup-mold@354d1662b2a6f02e5eccc9712f22657621bf645b # does not have recent tags
+
+      - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2.7.0 
+
+      - run: cargo +${{ steps.toolchain.outputs.name }} build --all-targets --all-features --verbose
+
+  test-extra:
+    name: "cargo test [dynamic]"
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        runner: [ubuntu-22.04, windows-2022, macos-12]
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: step-security/harden-runner@1b05615854632b887b69ae1be8cbefe72d3ae423 # v2.6.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+
+      - uses: ./.github/actions/setup-libmagic
+        with:
+          linkage: dynamic
+
+      - id: toolchain
+        uses: dtolnay/rust-toolchain@439cf607258077187679211f12aa6f19af4a0af7 # doesn't have usual versioned releases/tags
+        with:
+          toolchain: "1.54.0" # hardcoded crate MSRV, see rust-toolchain.toml etc.
+          # minimal profile includes rustc component which includes cargo and rustdoc
+
+      - uses: rui314/setup-mold@354d1662b2a6f02e5eccc9712f22657621bf645b # does not have recent tags
+
+      - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2.7.0 
+
+      - run: cargo +${{ steps.toolchain.outputs.name }} test --all-targets --all-features --verbose
+
+  cargo-vcpkg-extra:
+    name: "cargo vcpkg && cargo test"
+    permissions:
+      contents: read
+    runs-on: windows-2022
+    steps:
+      - uses: step-security/harden-runner@1b05615854632b887b69ae1be8cbefe72d3ae423 # v2.6.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+
+      - id: toolchain
+        uses: dtolnay/rust-toolchain@439cf607258077187679211f12aa6f19af4a0af7 # doesn't have usual versioned releases/tags
+        with:
+          toolchain: "1.54.0" # hardcoded crate MSRV, see rust-toolchain.toml etc.
+          # minimal profile includes rustc component which includes cargo and rustdoc
+
+      - uses: rui314/setup-mold@354d1662b2a6f02e5eccc9712f22657621bf645b # does not have recent tags
+
+      - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2.7.0
+
+      - uses: taiki-e/install-action@ebb475ef6e41abb770588020cd8c6ca3503cb868 # v2.19.4
+        with:
+          tool: cargo-vcpkg@0.1.7
+
+      - name: expose cache
+        if: ${{ runner.os == 'Windows' }}
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+      - name: setup cache
+        run: echo "VCPKG_BINARY_SOURCES=clear;x-gha,readwrite" >> "${GITHUB_ENV}"
+        shell: bash
+
+      - run: cargo +${{ steps.toolchain.outputs.name }} vcpkg --verbose build
+
+      - run: cargo +${{ steps.toolchain.outputs.name }} test --all-targets --all-features --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ vcpkg = { version = "0.2.15", optional = true }
 
 [package.metadata.vcpkg]
 git = "https://github.com/microsoft/vcpkg"
-rev = "078f3e5"
+rev = "9edb1b8e590cc086563301d735cae4b6e732d2d2" # 2023.08.09
 dependencies = ["libmagic"]
 
 [dependencies.libc]


### PR DESCRIPTION
This runs `cargo build` and `cargo test` while dynamically linking against `libmagic`.
The non-extra build does the same but statically.

This also uses `cargo vcpkg` with `cargo test` and defaults for Windows.
Building without `vcpkg` on Windows, e.g. with MSYS2 for target `x86_64-pc-windows-gnu`, is untested and thus unsupported for now.