### PR TITLE
Remove obsolete `libmagic` version features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,21 +32,9 @@ rust-version = "1.54"
 maintenance = { status = "passively-maintained" }
 
 [features]
-default = ["v5-38", "pkg-config", "vcpkg"]
-v5-04 = []
-v5-05 = ["v5-04"]
-v5-10 = ["v5-05"]
-v5-13 = ["v5-10"]
-v5-20 = ["v5-13"]
-v5-21 = ["v5-20"]
-v5-22 = ["v5-21"]
-v5-23 = ["v5-22"]
-v5-25 = ["v5-23"]
-v5-27 = ["v5-25"]
-v5-32 = ["v5-27"]
-v5-35 = ["v5-32"]
-v5-38 = ["v5-35"]
-v5-40 = ["v5-38"]
+default = ["pkg-config", "vcpkg"]
+# the "default" version feature would be v5-39, but that's API-wise the same as v5-38
+v5-40 = []
 
 [build-dependencies]
 pkg-config = { version = "0.3.27", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 //! - `vcpkg`: Enables using [`vcpkg`](https://vcpkg.io/)
 //! with the [`vcpkg` crate](https://docs.rs/vcpkg) in the build script\
 //! Check the [crate README](https://crates.io/crates/magic#vcpkg) for configuration details
+//! - `v5-40`: Enables using API of `libmagic` version 5.40
 //!
 //! The following features are enabled by default:
 //! - `pkg-config`
@@ -18,7 +19,6 @@
 #![cfg_attr(not(test), no_std)]
 
 extern crate libc;
-#[cfg(feature = "v5-20")]
 use libc::c_void;
 use libc::{c_char, c_int, size_t};
 
@@ -49,11 +49,8 @@ pub const MAGIC_ERROR: c_int = 0x000_0200;
 pub const MAGIC_MIME_ENCODING: c_int = 0x000_0400;
 pub const MAGIC_MIME: c_int = MAGIC_MIME_TYPE | MAGIC_MIME_ENCODING;
 pub const MAGIC_APPLE: c_int = 0x00_0800;
-#[cfg(feature = "v5-23")]
 pub const MAGIC_EXTENSION: c_int = 0x100_0000;
-#[cfg(feature = "v5-23")]
 pub const MAGIC_COMPRESS_TRANSP: c_int = 0x200_0000;
-#[cfg(feature = "v5-23")]
 pub const MAGIC_NODESC: c_int = MAGIC_EXTENSION | MAGIC_MIME | MAGIC_APPLE;
 
 pub const MAGIC_NO_CHECK_COMPRESS: c_int = 0x000_1000;
@@ -63,37 +60,11 @@ pub const MAGIC_NO_CHECK_APPTYPE: c_int = 0x000_8000;
 pub const MAGIC_NO_CHECK_ELF: c_int = 0x001_0000;
 pub const MAGIC_NO_CHECK_TEXT: c_int = 0x002_0000;
 pub const MAGIC_NO_CHECK_CDF: c_int = 0x004_0000;
-#[cfg(feature = "v5-38")]
 pub const MAGIC_NO_CHECK_CSV: c_int = 0x008_0000;
 pub const MAGIC_NO_CHECK_TOKENS: c_int = 0x010_0000;
 pub const MAGIC_NO_CHECK_ENCODING: c_int = 0x020_0000;
-#[cfg(feature = "v5-35")]
 pub const MAGIC_NO_CHECK_JSON: c_int = 0x040_0000;
 
-#[cfg(all(feature = "v5-05", not(feature = "v5-10")))]
-pub const MAGIC_NO_CHECK_BUILTIN: c_int = 0x3f_b000;
-#[cfg(all(feature = "v5-10", not(feature = "v5-35")))]
-pub const MAGIC_NO_CHECK_BUILTIN: c_int = MAGIC_NO_CHECK_COMPRESS |
-MAGIC_NO_CHECK_TAR      |
-// MAGIC_NO_CHECK_SOFT  |
-MAGIC_NO_CHECK_APPTYPE  |
-MAGIC_NO_CHECK_ELF      |
-MAGIC_NO_CHECK_TEXT     |
-MAGIC_NO_CHECK_CDF      |
-MAGIC_NO_CHECK_TOKENS   |
-MAGIC_NO_CHECK_ENCODING;
-#[cfg(all(feature = "v5-35", not(feature = "v5-38")))]
-pub const MAGIC_NO_CHECK_BUILTIN: c_int = MAGIC_NO_CHECK_COMPRESS |
-MAGIC_NO_CHECK_TAR      |
-// MAGIC_NO_CHECK_SOFT  |
-MAGIC_NO_CHECK_APPTYPE  |
-MAGIC_NO_CHECK_ELF      |
-MAGIC_NO_CHECK_TEXT     |
-MAGIC_NO_CHECK_CDF      |
-MAGIC_NO_CHECK_TOKENS   |
-MAGIC_NO_CHECK_ENCODING |
-MAGIC_NO_CHECK_JSON;
-#[cfg(feature = "v5-38")]
 pub const MAGIC_NO_CHECK_BUILTIN: c_int = MAGIC_NO_CHECK_COMPRESS |
 MAGIC_NO_CHECK_TAR      |
 // MAGIC_NO_CHECK_SOFT  |
@@ -118,54 +89,39 @@ pub const MAGIC_NO_CHECK_TROFF: c_int = 0x00_0000;
 
 // TODO: MAGIC_SNPRINTB bytes
 
-#[cfg(feature = "v5-21")]
 pub const MAGIC_PARAM_INDIR_MAX: c_int = 0;
-#[cfg(feature = "v5-21")]
 pub const MAGIC_PARAM_NAME_MAX: c_int = 1;
-#[cfg(feature = "v5-21")]
 pub const MAGIC_PARAM_ELF_PHNUM_MAX: c_int = 2;
-#[cfg(feature = "v5-21")]
 pub const MAGIC_PARAM_ELF_SHNUM_MAX: c_int = 3;
-#[cfg(feature = "v5-22")]
 pub const MAGIC_PARAM_ELF_NOTES_MAX: c_int = 4;
-#[cfg(feature = "v5-25")]
 pub const MAGIC_PARAM_REGEX_MAX: c_int = 5;
-#[cfg(feature = "v5-27")]
 pub const MAGIC_PARAM_BYTES_MAX: c_int = 6;
 #[cfg(feature = "v5-40")]
 pub const MAGIC_PARAM_ENCODING_MAX: c_int = 7;
 
 // NOTE: the following are from `file.h`, but part of `magic.h` API
-#[cfg(feature = "v5-04")]
 pub const FILE_LOAD: c_int = 0;
-#[cfg(feature = "v5-04")]
 pub const FILE_CHECK: c_int = 1;
-#[cfg(feature = "v5-04")]
 pub const FILE_COMPILE: c_int = 2;
-#[cfg(feature = "v5-05")]
 pub const FILE_LIST: c_int = 3;
 
 extern "C" {
     pub fn magic_open(flags: c_int) -> magic_t;
     pub fn magic_close(cookie: magic_t);
 
-    #[cfg(feature = "v5-04")]
     pub fn magic_getpath(magicfile: *const c_char, action: c_int) -> *const c_char;
     pub fn magic_file(cookie: magic_t, filename: *const c_char) -> *const c_char;
     pub fn magic_descriptor(cookie: magic_t, fd: c_int) -> *const c_char;
     pub fn magic_buffer(cookie: magic_t, buffer: *const u8, length: size_t) -> *const c_char;
 
     pub fn magic_error(cookie: magic_t) -> *const c_char;
-    #[cfg(feature = "v5-32")]
     pub fn magic_getflags(cookie: magic_t) -> c_int;
     #[must_use]
     pub fn magic_setflags(cookie: magic_t, flags: c_int) -> c_int;
 
-    #[cfg(feature = "v5-13")]
     pub fn magic_version() -> c_int;
     #[must_use]
     pub fn magic_load(cookie: magic_t, filename: *const c_char) -> c_int;
-    #[cfg(feature = "v5-20")]
     #[must_use]
     pub fn magic_load_buffers(
         cookie: magic_t,
@@ -178,15 +134,12 @@ extern "C" {
     pub fn magic_compile(cookie: magic_t, filename: *const c_char) -> c_int;
     #[must_use]
     pub fn magic_check(cookie: magic_t, filename: *const c_char) -> c_int;
-    #[cfg(feature = "v5-05")]
     #[must_use]
     pub fn magic_list(cookie: magic_t, filename: *const c_char) -> c_int;
     pub fn magic_errno(cookie: magic_t) -> c_int;
 
-    #[cfg(feature = "v5-21")]
     #[must_use]
     pub fn magic_setparam(cookie: magic_t, param: c_int, value: *const c_void) -> c_int;
-    #[cfg(feature = "v5-21")]
     #[must_use]
     pub fn magic_getparam(cookie: magic_t, param: c_int, value: *mut c_void) -> c_int;
 }
@@ -212,7 +165,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "v5-04")]
     #[test]
     fn test_magic_getpath() {
         unsafe {
@@ -248,7 +200,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "v5-32")]
     #[test]
     fn test_magic_getflags() {
         unsafe {
@@ -263,7 +214,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "v5-13")]
     #[test]
     fn test_magic_version() {
         unsafe {
@@ -278,7 +228,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "v5-20")]
     #[test]
     fn test_magic_load_buffers() {
         unsafe {
@@ -305,7 +254,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "v5-05")]
     #[test]
     fn test_magic_list() {
         unsafe {
@@ -320,7 +268,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "v5-21")]
     #[test]
     fn test_magic_setparam() {
         unsafe {
@@ -332,7 +279,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "v5-21")]
     #[test]
     fn test_magic_getparam() {
         unsafe {


### PR DESCRIPTION
This removes old features (see https://github.com/robo9k/rust-magic-sys/issues/36#issuecomment-1745873239) that are now implicit since we require `libmagic` 5.39+ (see #39)

Technically this is a breaking change, but that was introduced with #39 already.