### PR TITLE
Fix Windows build

### DIFF
--- a/.github/actions/setup-libmagic/action.yml
+++ b/.github/actions/setup-libmagic/action.yml
@@ -93,7 +93,9 @@ runs:
 
     - name: update packages
       if: ${{ runner.os == 'Windows' }}
-      run: vcpkg update
+      run: |
+        git -C "${VCPKG_INSTALLATION_ROOT}" pull
+        vcpkg update
       shell: bash
 
     - name: update packages

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ vcpkg = { version = "0.2.15", optional = true }
 
 [package.metadata.vcpkg]
 git = "https://github.com/microsoft/vcpkg"
-rev = "9edb1b8e590cc086563301d735cae4b6e732d2d2" # 2023.08.09
+rev = "a0f974c66a1c56e974d37b5707e312742aead974" # https://github.com/microsoft/vcpkg/pull/43635
 dependencies = ["libmagic"]
 
 [dependencies.libc]


### PR DESCRIPTION
There's issues with stale vcpkg ports as well as old ports rev, depending on installation method / workflow.