### PR TITLE
Apply zizmor remediations to `setup-libmagic` action

### DIFF
--- a/.github/actions/setup-libmagic/action.yml
+++ b/.github/actions/setup-libmagic/action.yml
@@ -11,11 +11,13 @@ runs:
     # check inputs
     - name: check inputs
       run: |
-        if [[ ! ("${{ inputs.linkage }}" == "static" || "${{ inputs.linkage }}" == "dynamic") ]]; then
-          echo "'linkage' input must be either 'static' or 'dynamic' but it is: ${{ inputs.linkage }}"
+        if [[ ! ("${INPUT_LINKAGE}" == "static" || "${INPUT_LINKAGE}" == "dynamic") ]]; then
+          echo "'linkage' input must be either 'static' or 'dynamic' but it is: ${INPUT_LINKAGE}"
           exit 1
         fi
       shell: bash
+      env:
+        INPUT_LINKAGE: ${{ inputs.linkage }}
 
 
     # setup environment
@@ -41,33 +43,39 @@ runs:
     - name: setup linkage
       if: ${{ runner.os == 'Linux' }}
       run: |
-        if [[ "${{ inputs.linkage }}" == "static" ]]; then
+        if [[ "${INPUT_LINKAGE}" == "static" ]]; then
           echo "LIBMAGIC_STATIC=1" >> "${GITHUB_ENV}"
-        elif [[ "${{ inputs.linkage }}" == "dynamic" ]]; then
+        elif [[ "${INPUT_LINKAGE}" == "dynamic" ]]; then
           echo "LIBMAGIC_DYNAMIC=1" >> "${GITHUB_ENV}"
         fi
       shell: bash
+      env:
+        INPUT_LINKAGE: ${{ inputs.linkage }}
 
     - name: setup linkage
       if: ${{ runner.os == 'Windows' }}
       run: |
-        if [[ "${{ inputs.linkage }}" == "static" ]]; then
+        if [[ "${INPUT_LINKAGE}" == "static" ]]; then
           echo "VCPKG_DEFAULT_TRIPLET=x64-windows-static-md" >> "${GITHUB_ENV}"
-        elif [[ "${{ inputs.linkage }}" == "dynamic" ]]; then
+        elif [[ "${INPUT_LINKAGE}" == "dynamic" ]]; then
           echo "VCPKG_DEFAULT_TRIPLET=x64-windows" >> "${GITHUB_ENV}"
           echo "VCPKGRS_DYNAMIC=1" >> "${GITHUB_ENV}"
         fi
       shell: bash
+      env:
+        INPUT_LINKAGE: ${{ inputs.linkage }}
 
     - name: setup linkage
       if: ${{ runner.os == 'macOS' }}
       run: |
-        if [[ "${{ inputs.linkage }}" == "static" ]]; then
+        if [[ "${INPUT_LINKAGE}" == "static" ]]; then
           echo "LIBMAGIC_STATIC=1" >> "${GITHUB_ENV}"
-        elif [[ "${{ inputs.linkage }}" == "dynamic" ]]; then
+        elif [[ "${INPUT_LINKAGE}" == "dynamic" ]]; then
           echo "LIBMAGIC_DYNAMIC=1" >> "${GITHUB_ENV}"
         fi
       shell: bash
+      env:
+        INPUT_LINKAGE: ${{ inputs.linkage }}
 
 
     # vcpkg cache
@@ -117,9 +125,11 @@ runs:
 
     - name: install packages
       if: ${{ runner.os == 'Windows' }}
+      # see https://github.com/robo9k/rust-magic-sys/pull/59 for not using VCPKG_INSTALLATION_ROOT
       run: |
         vcpkg install libmagic
-        echo "VCPKG_ROOT=${VCPKG_INSTALLATION_ROOT}" >> "${GITHUB_ENV}"
+        echo "VCPKG_INSTALLATION_ROOT: ${VCPKG_INSTALLATION_ROOT}"
+        echo "VCPKG_ROOT=C:\vcpkg" >> "${GITHUB_ENV}"
       shell: bash
 
     - name: install packages


### PR DESCRIPTION
> [`zizmor`](https://woodruffw.github.io/zizmor/) is a static analysis tool for GitHub Actions. It can find many common security issues in typical GitHub Actions CI/CD setups.

Running it on `.github/actions/setup-libmagic/action.yml` yields a few `template-injection` results which can be fixed mechanically.

There is one `github-env` result regarding `VCPKG_INSTALLATION_ROOT`
According to the GitHub docs this environment variable is always set to the same "C:\vcpkg" value
- https://github.com/actions/runner-images/blob/main/images/windows/Windows2019-Readme.md
- https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md 
- https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md

There's different options:
1. ignore the zizmor finding https://woodruffw.github.io/zizmor/usage/#ignoring-results
   leaves potential security issue unfixed
2. hardcode the environment value
   might break action when GitHub publishes new runner
3. use `GITHUB_OUTPUT` instead of `GITHUB_ENV` everywhere
   makes the action difficult to use