### PR TITLE
chore(deps): update taiki-e/install-action action to v2.56.14

### DIFF
--- a/.github/workflows/build-extra.yml
+++ b/.github/workflows/build-extra.yml
@@ -101,7 +101,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
 
-      - uses: taiki-e/install-action@ebb475ef6e41abb770588020cd8c6ca3503cb868 # v2.19.4
+      - uses: taiki-e/install-action@2790298ea2e5d83ad59ad1ea90fac1df6f79f605 # v2.56.14
         with:
           tool: cargo-vcpkg@0.1.7
 

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -23,7 +23,7 @@ jobs:
                 # pick the pr HEAD instead of the merge commit
                 ref: ${{ github.event.pull_request.head.sha }}
 
-            - uses: taiki-e/install-action@57aaba576a0253b74662df51e62715622f02127b # v2.19.2
+            - uses: taiki-e/install-action@2790298ea2e5d83ad59ad1ea90fac1df6f79f605 # v2.56.14
               with:
                 tool: cocogitto@5.5.0
 

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: ./.github/actions/setup-libmagic
 
-      - uses: taiki-e/install-action@47d27149ff6b3422864ec504071d5cc7873d642e # v2.20.3
+      - uses: taiki-e/install-action@2790298ea2e5d83ad59ad1ea90fac1df6f79f605 # v2.56.14
         with:
           tool: cargo-msrv@0.18.4
 

--- a/.github/workflows/test-libmagic-version.yml
+++ b/.github/workflows/test-libmagic-version.yml
@@ -101,7 +101,7 @@ jobs:
 
       - run: cargo +${{ steps.toolchain.outputs.name }} test --all-targets --features '${{ matrix.feature }}' --verbose
 
-      - uses: taiki-e/install-action@47d27149ff6b3422864ec504071d5cc7873d642e # v2.20.3
+      - uses: taiki-e/install-action@2790298ea2e5d83ad59ad1ea90fac1df6f79f605 # v2.56.14
         with:
           tool: bindgen-cli@0.68.1
 


### PR DESCRIPTION
Renovate seems to get stuck fetching changelogs and then its whole job is `FAILED` with "worker-signaled"

Despite not being able to create a matching merge request, the branch itself was created successfully.
