### PR TITLE
Deny external crate dependencies with default feature in CI

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -6,6 +6,7 @@ allow = [
 
 [bans]
 wildcards = "deny"
+external-default-features = "deny"
 
 [sources]
 unknown-registry = "deny"


### PR DESCRIPTION
See https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html#the-external-default-features-field-optional

Confusingly `cargo tree` reports the "default" feature:
```terminal
 cargo +stable tree --edges features
magic-sys v0.3.0 (/tmp/rust-magic-sys)
└── libc v0.2.104
[build-dependencies]
├── pkg-config feature "default"
│   └── pkg-config v0.3.27
└── vcpkg feature "default"
    └── vcpkg v0.2.15
```

Even though those two crates do not have any features:
- https://docs.rs/crate/pkg-config/0.3.27/source/Cargo.toml
- https://docs.rs/crate/vcpkg/0.2.15/source/Cargo.toml

`cargo deny check bans` does not report this as a diagnostic even though currently the two crates are not explicitly opt-out
It should however fail the build in the future if e.g. they do gain a `default` feature and Renovate updates just their version