### PR TITLE
Deny crate dependencies with build scripts in CI

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -8,6 +8,12 @@ allow = [
 wildcards = "deny"
 external-default-features = "deny"
 
+[bans.build]
+allow-build-scripts = [
+    # https://docs.rs/crate/libc/0.2.104/source/build.rs
+    { name = "libc" },
+]
+
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"


### PR DESCRIPTION
See https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html#the-allow-build-scripts-field-optional

Especially note that this is for awareness and not bulletproof:
> While the intention of this configuration is to raise awareness of crates that have or use precompiled binaries or scripts, or otherwise contain file types that you want to be aware of, the compile time crate linting supplied by `cargo-deny` does NOT protect you from actively malicious code.