### PR TITLE
Remove unsupported vcpkg x-gha cache in CI

### DIFF
--- a/.github/actions/setup-libmagic/action.yml
+++ b/.github/actions/setup-libmagic/action.yml
@@ -78,20 +78,6 @@ runs:
         INPUT_LINKAGE: ${{ inputs.linkage }}
 
 
-    # vcpkg cache
-    - name: expose cache
-      if: ${{ runner.os == 'Windows' }}
-      uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
-      with:
-        script: |
-          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-    - name: setup cache
-      if: ${{ runner.os == 'Windows' }}
-      run: echo "VCPKG_BINARY_SOURCES=clear;x-gha,readwrite" >> "${GITHUB_ENV}"
-      shell: bash
-
-
     # update packages
 
     - name: update packages

--- a/.github/workflows/build-extra.yml
+++ b/.github/workflows/build-extra.yml
@@ -105,18 +105,6 @@ jobs:
         with:
           tool: cargo-vcpkg@0.1.7
 
-      - name: expose cache
-        if: ${{ runner.os == 'Windows' }}
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-
-      - name: setup cache
-        run: echo "VCPKG_BINARY_SOURCES=clear;x-gha,readwrite" >> "${GITHUB_ENV}"
-        shell: bash
-
       - run: cargo +${{ steps.toolchain.outputs.name }} vcpkg --verbose build
 
       - run: cargo +${{ steps.toolchain.outputs.name }} test --all-targets --all-features --verbose


### PR DESCRIPTION
`vcpkg` removed their `x-gha` binary cache provider, see https://redirect.github.com/microsoft/vcpkg-tool/pull/1662

Since it's already doing nothing, remove it from our CI as well.
This means Windows builds take +~5mins

There's some alternatives using `actions/cache` manually and the file/local cache provider of vcpkg
This might be worthwhile for a follow-up issue, but note that GHA ache size is already approaching its limit anyway