### PR TITLE
Use current pinned stable Rust toolchain v1.88.0 while keeping MSRV

### DIFF
--- a/.github/workflows/build-extra.yml
+++ b/.github/workflows/build-extra.yml
@@ -34,7 +34,7 @@ jobs:
       - id: toolchain
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # doesn't have usual versioned releases/tags
         with:
-          toolchain: "1.54.0" # hardcoded crate MSRV, see rust-toolchain.toml etc.
+          toolchain: "1.88.0" # current pinned stable
           # minimal profile includes rustc component which includes cargo and rustdoc
 
       - uses: rui314/setup-mold@702b1908b5edf30d71a8d1666b724e0f0c6fa035 # does not have recent tags
@@ -68,7 +68,7 @@ jobs:
       - id: toolchain
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # doesn't have usual versioned releases/tags
         with:
-          toolchain: "1.54.0" # hardcoded crate MSRV, see rust-toolchain.toml etc.
+          toolchain: "1.88.0" # current pinned stable
           # minimal profile includes rustc component which includes cargo and rustdoc
 
       - uses: rui314/setup-mold@702b1908b5edf30d71a8d1666b724e0f0c6fa035 # does not have recent tags
@@ -94,7 +94,7 @@ jobs:
       - id: toolchain
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # doesn't have usual versioned releases/tags
         with:
-          toolchain: "1.54.0" # hardcoded crate MSRV, see rust-toolchain.toml etc.
+          toolchain: "1.88.0" # current pinned stable
           # minimal profile includes rustc component which includes cargo and rustdoc
 
       - uses: rui314/setup-mold@702b1908b5edf30d71a8d1666b724e0f0c6fa035 # does not have recent tags

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - id: toolchain
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # doesn't have usual versioned releases/tags
         with:
-          toolchain: "1.54.0" # hardcoded crate MSRV, see rust-toolchain.toml etc.
+          toolchain: "1.88.0" # current pinned stable
           # minimal profile includes rustc component which includes cargo and rustdoc
 
       - uses: rui314/setup-mold@702b1908b5edf30d71a8d1666b724e0f0c6fa035 # does not have recent tags
@@ -64,7 +64,7 @@ jobs:
       - id: toolchain
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # doesn't have usual versioned releases/tags
         with:
-          toolchain: "1.54.0" # hardcoded crate MSRV, see rust-toolchain.toml etc.
+          toolchain: "1.88.0" # current pinned stable
           # minimal profile includes rustc component which includes cargo and rustdoc
 
       - uses: rui314/setup-mold@702b1908b5edf30d71a8d1666b724e0f0c6fa035 # does not have recent tags

--- a/.github/workflows/test-libmagic-version.yml
+++ b/.github/workflows/test-libmagic-version.yml
@@ -91,7 +91,7 @@ jobs:
       - id: toolchain
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # doesn't have usual versioned releases/tags
         with:
-          toolchain: "1.54.0" # hardcoded crate MSRV, see rust-toolchain.toml etc.
+          toolchain: "1.88.0" # current pinned stable
           # minimal profile includes rustc component which includes cargo and rustdoc
           components: "rustfmt"
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.54.0"
+channel = "1.88.0" # current pinned stable


### PR DESCRIPTION
This makes it easier to later update MSRV in one place only
The MSRV check is still in place and MSRV is unchanged, so #73 should continue to fail

Should also result in some performance and UX improvements, see https://github.com/robo9k/rust-magic-sys/pull/61#issuecomment-3074121647

Renovate could be used to update the pinned stable version in a follow-up, even though it does not support Rust toolchains directly currently