### PR TITLE
Use Renovate preset to set semantic commit type for crate build-dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,5 +3,6 @@
   extends: [
     "config:recommended",
     ":semanticCommits",
+    "robo9k/renovate-config:crateSemanticCommitTypeFix",
   ],
 }


### PR DESCRIPTION
See https://redirect.github.com/renovatebot/renovate/discussions/37025

Instead of "chore(deps): update rust crate pkg-config to v0.3.32"
I want "fix(deps): update rust crate pkg-config to v0.3.32"