### PR TITLE
Run `cargo` with `--locked` in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,8 +54,8 @@ jobs:
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0 
 
       - run: cargo --verbose --version
-      - run: cargo build --all-targets --all-features
-      - run: cargo test --all-targets --all-features
+      - run: cargo build --locked --all-targets --all-features
+      - run: cargo test --locked --all-targets --all-features
 
   cargo-vcpkg-and-build-and-test:
     name: "cargo vcpkg build && cargo build && cargo test"
@@ -91,5 +91,5 @@ jobs:
       - run: cargo --verbose --version
       - run: cargo vcpkg --verbose build
       - run: echo "LIBMAGIC_NO_PKG_CONFIG=true" >> "${GITHUB_ENV}"
-      - run: cargo build --all-targets --all-features
-      - run: cargo test --all-targets --all-features
+      - run: cargo build --locked --all-targets --all-features
+      - run: cargo test --locked --all-targets --all-features

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -38,11 +38,11 @@ jobs:
         env:
           RUSTUP_TOOLCHAIN: ${{ steps.toolchain.outputs.name }}
 
-      - run: cargo msrv verify --output-format json
+      - run: cargo msrv verify --output-format json -- cargo test --locked --all-targets --all-features
         env:
           RUSTUP_TOOLCHAIN: ${{ steps.toolchain.outputs.name }}
 
       - if: ${{ failure() }}
-        run: cargo msrv find --output-format json
+        run: cargo msrv find --output-format json -- cargo test --locked --all-targets --all-features
         env:
           RUSTUP_TOOLCHAIN: ${{ steps.toolchain.outputs.name }}

--- a/.github/workflows/test-libmagic-version.yml
+++ b/.github/workflows/test-libmagic-version.yml
@@ -99,7 +99,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0 
 
-      - run: cargo +${{ steps.toolchain.outputs.name }} test --all-targets --features '${{ matrix.feature }}' --verbose
+      - run: cargo +${{ steps.toolchain.outputs.name }} test --locked --all-targets --features '${{ matrix.feature }}' --verbose
 
       - uses: taiki-e/install-action@8520ed0913d842fe1061358cb4d010ef346b0ea9 # v2.56.16
         with:


### PR DESCRIPTION
This partially implements #91 

~~There's probably some implicit invocations of `cargo` not yet covered, e.g. for MSRV~~