### PR TITLE
Add and use action to use vcpkg files cache in CI

### DIFF
--- a/.github/actions/vcpkg-files-cache/action.yml
+++ b/.github/actions/vcpkg-files-cache/action.yml
@@ -1,0 +1,45 @@
+name: vcpkg-files-cache
+description: Setup files cache for vcpkg
+
+inputs:
+  directory:
+    description: directory for this vcpkg files cache
+    default: ${{ runner.temp }}/vcpkg-cache/
+  cache-key:
+    description: suffix for computed cache key
+    required: false
+
+runs:
+  using: 'composite'
+  steps:
+    # create cache directory and key
+    - name: mkdir
+      id: cache-directory
+      run: |
+        mkdir --parents "${INPUT_DIRECTORY}"
+
+        CACHE_DIR=$(realpath "${INPUT_DIRECTORY}")
+        echo "path=${CACHE_DIR}" >> "${GITHUB_OUTPUT}"
+
+        CACHE_DIR_HASH=$(echo "${CACHE_DIR}" | sha256sum)
+        echo "hash=${CACHE_DIR_HASH%% *}" >> "${GITHUB_OUTPUT}"
+      shell: bash
+      env:
+        INPUT_DIRECTORY: ${{ inputs.directory }}
+
+    # add binary source
+    - name: setup vcpkg binary sources
+      run: | # zizmor: ignore[github-env] the variable contents for VCPKG_BINARY_SOURCES come from inputs.directory which is not attacker-controlled, usually
+        BINARY_SOURCE="files,${CACHE_DIR},readwrite"
+        echo "VCPKG_BINARY_SOURCES=${VCPKG_BINARY_SOURCES};${BINARY_SOURCE}" >> "${GITHUB_ENV}"
+      shell: bash
+      env:
+        CACHE_DIR: ${{ steps.cache-directory.outputs.path }}
+
+    # setup cache action
+    - name: setup actions/cache
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        key: vcpkg-${{ github.job }}-${{ runner.os }}-${{ steps.cache-directory.outputs.hash }}${{ inputs.cache-key }}
+        path: ${{ steps.cache-directory.outputs.path }}
+        # should have inputs for: lookup-only

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,10 @@ env:
   CARGO_TERM_VERBOSE: "true"
   CARGO_TERM_COLOR: "always"
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build-and-test:
     name: "cargo build && cargo test"
@@ -34,6 +38,15 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
+
+      # disable vcpkg default binary cache
+      - if: ${{ runner.os == 'Windows' }}
+        run: echo "VCPKG_BINARY_SOURCES=clear" >> "${GITHUB_ENV}"
+
+      - if: ${{ runner.os == 'Windows' }}
+        uses: ./.github/actions/vcpkg-files-cache
+        with:
+          cache-key: ${{ matrix.libmagic-linkage }}
 
       - uses: ./.github/actions/setup-libmagic
         with:
@@ -87,6 +100,10 @@ jobs:
         with:
           # renovate: taiki-e/install-action
           tool: cargo-vcpkg@0.1.7
+
+      # disable vcpkg default binary cache
+      - run: echo "VCPKG_BINARY_SOURCES=clear" >> "${GITHUB_ENV}"
+      - uses: ./.github/actions/vcpkg-files-cache
 
       - run: cargo --verbose --version
       - run: cargo vcpkg --verbose build


### PR DESCRIPTION
This partially implements #92 

This implements https://github.com/robo9k/rust-magic-sys/pull/84#issue-3236783283

See https://learn.microsoft.com/en-us/vcpkg/consume/binary-caching-local
Does not use GitHub NuGet Packages since that's a lot less plug & play