### PR TITLE
Document crate features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,11 +34,13 @@ maintenance = { status = "passively-maintained" }
 
 [features]
 default = ["pkg-config", "vcpkg"]
-# the "default" version feature would be v5-39, but that's API-wise the same as v5-38
+## Enable `libmagic` v5.40 API
 v5-40 = []
 
 [build-dependencies]
+## Enable build using `pkg-config`
 pkg-config = { version = "0.3.27", optional = true }
+## Enable build using `vcpkg`
 vcpkg = { version = "0.2.15", optional = true }
 
 [package.metadata.vcpkg]
@@ -53,5 +55,6 @@ x86_64-pc-windows-msvc = { triplet = "x64-windows-static-md" }
 msrv = "1.64.0"
 
 [package.metadata.docs.rs]
-all-features = true
 targets = []
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/README.md
+++ b/README.md
@@ -56,15 +56,15 @@ The `libmagic` API is extended with new backwards-compatible features every now 
 To use newly added `libmagic` functionality, you need to use a corresponding `libmagic` version.
 
 You need to specify your `libmagic` version by activating the matching `magic-sys` feature.\
-Each API version has a crate feature like "v5-38" (v5.38 is also the default), see [Cargo.toml](Cargo.toml)\
+Each API version has a crate feature like "v5-40", see [Cargo.toml](Cargo.toml)\
 If you use a different version of `libmagic`, adjust your configuration:
 ```toml
 [dependencies.magic-sys]
 version = "0.3"
 default-features = false
-features = ["v5-41"]
+features = ["v5-40"]
 ```
-Note that those version features are additive, so "v5-41" implies "v5-40" and other previous versions.
+Note that those version features are additive, so "v5-45" implies "v5-44" and other previous versions.
 
 If you want to use a newer/different `libmagic` version, you will have to [link it](#Building) accordingly.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,65 @@
 //! # Features
 //!
-//! This crate has the following [features](https://doc.rust-lang.org/cargo/reference/features.html#features):
+//! ## Build features
+//! - `pkg-config` (_enabled by default_) — Enable build using [`pkg-config`](https://www.freedesktop.org/wiki/Software/pkg-config/) with the [`pkg-config` crate](https://docs.rs/pkg-config)  
+//!   Check the [crate README for `pkg-config` configuration details](https://crates.io/crates/magic#pkg-config)
+//! - `vcpkg` (_enabled by default_) — Enable build using [`vcpkg`](https://vcpkg.io/) with the [`vcpkg` crate](https://docs.rs/vcpkg)  
+//!   Check the [crate README for `vcpkg` configuration details](https://crates.io/crates/magic#vcpkg)
 //!
-//! - `pkg-config`: Enables using [`pkg-config`](https://www.freedesktop.org/wiki/Software/pkg-config/)
-//!   with the [`pkg-config` crate](https://docs.rs/pkg-config) in the build script  
-//!   Check the [crate README](https://crates.io/crates/magic#pkg-config) for configuration details
-//! - `vcpkg`: Enables using [`vcpkg`](https://vcpkg.io/)
-//!   with the [`vcpkg` crate](https://docs.rs/vcpkg) in the build script  
-//!   Check the [crate README](https://crates.io/crates/magic#vcpkg) for configuration details
-//! - `v5-40`: Enables using API of `libmagic` version 5.40
+//! ## `libmagic` API features
+//! - `v5-40` — Enable [`libmagic` v5.40 API](#libmagic-v540)
 //!
-//! The following features are enabled by default:
-//! - `pkg-config`
-//! - `vcpkg`
+//!
+//! # `libmagic` changelog
+//!
+//! The following is a subset of `libmagic` changes that are relevant for this `magic-sys` crate.
+//!
+//! `magic-sys` implements `libmagic` API v5.38 ..= v5.40.  
+//! `magic-sys` requires `libmagic` v5.39 or any newer version to build.  
+//!
+//! ## `libmagic` v5.38
+//!
+//! API baseline.  
+//!
+//! ## `libmagic` v5.39
+//!
+//! No API changes.  
+//! Add `libmagic.pc` to build (statically) with `pkg-config`.  
+//!
+//! ## `libmagic` v5.40
+//!
+//! Add [`MAGIC_PARAM_ENCODING_MAX`].  
+//!
+// not yet implemented
+// ## `libmagic` v5.41
+//
+// No API changes.
+//
+// ## `libmagic` v5.42
+//
+// No API changes.
+//
+// ## `libmagic` v5.43
+//
+// No API changes.
+//
+// ## `libmagic` v5.44
+//
+// Add [`MAGIC_NO_COMPRESS_FORK`].
+//
+// ## `libmagic` v5.45
+//
+// Add [`MAGIC_NO_CHECK_SIMH`].
+// Add [`MAGIC_PARAM_ELF_SHSIZE_MAX`].
+//
+// ## `libmagic` v5.46
+//
+// No API changes.
+//
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg_hide))]
+#![cfg_attr(docsrs, doc(cfg_hide(docsrs)))]
 // Technically this crate doesn't need Rust `std`
 // but you'll still have to get the `libmagic` C library working for your target
 #![cfg_attr(not(test), no_std)]
@@ -96,6 +142,7 @@ pub const MAGIC_PARAM_ELF_SHNUM_MAX: c_int = 3;
 pub const MAGIC_PARAM_ELF_NOTES_MAX: c_int = 4;
 pub const MAGIC_PARAM_REGEX_MAX: c_int = 5;
 pub const MAGIC_PARAM_BYTES_MAX: c_int = 6;
+#[cfg_attr(docsrs, doc(cfg(feature = "v5-40")))]
 #[cfg(feature = "v5-40")]
 pub const MAGIC_PARAM_ENCODING_MAX: c_int = 7;
 


### PR DESCRIPTION
Fix incorrect old feature documentation and use format that is compatible with the `document-features` crate, but without the dependency.

Currently CI does not build `rustdoc`, but could use GitHub pages like [robo9k/rust-magic](https://github.com/robo9k/rust-magic) and maybe [dtolnay/cargo-docs-rs](https://github.com/dtolnay/cargo-docs-rs) in a follow-up