### PR TITLE
Determine vcpkg CI cache key from rev and linkage

### DIFF
--- a/.github/actions/setup-libmagic/action.yml
+++ b/.github/actions/setup-libmagic/action.yml
@@ -112,6 +112,27 @@ runs:
       shell: bash
 
 
+    # vcpkg files cache
+
+    - name: determine vcpkg cache key
+      id: cache-key
+      if: ${{ runner.os == 'Windows' }}
+      run: |
+        vcpkg_rev=$(git -C "${VCPKG_INSTALLATION_ROOT}" rev-parse HEAD)
+        cache_key="vcpkg-${vcpkg_rev}-windows-${INPUT_LINKAGE}-libmagic+pkgconf"
+
+        echo "key=${cache_key}" >> "${GITHUB_OUTPUT}"
+      env:
+        INPUT_LINKAGE: ${{ inputs.linkage }}
+      shell: bash
+
+    - name: setup vcpkg files cache
+      if: ${{ runner.os == 'Windows' }}
+      uses: ./.github/actions/vcpkg-files-cache
+      with:
+        cache-key: ${{ steps.cache-key.outputs.key }}
+
+
     # install packages
 
     - name: install packages

--- a/.github/actions/vcpkg-files-cache/action.yml
+++ b/.github/actions/vcpkg-files-cache/action.yml
@@ -19,6 +19,7 @@ runs:
 
         CACHE_DIR=$(realpath "${INPUT_DIRECTORY}")
         echo "path=${CACHE_DIR}" >> "${GITHUB_OUTPUT}"
+        echo "VCPKG_CACHE_DIR=${CACHE_DIR}" >> "${GITHUB_ENV}"
       shell: bash
       env:
         INPUT_DIRECTORY: ${{ inputs.directory }}
@@ -37,5 +38,5 @@ runs:
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         key: ${{ inputs.cache-key }}
-        path: ${{ steps.cache-directory.outputs.path }}
+        path: "${{ env.VCPKG_CACHE_DIR }}" # https://github.com/actions/cache/issues/803#issuecomment-1793565071
         # should have inputs for: lookup-only

--- a/.github/actions/vcpkg-files-cache/action.yml
+++ b/.github/actions/vcpkg-files-cache/action.yml
@@ -6,13 +6,12 @@ inputs:
     description: directory for this vcpkg files cache
     default: ${{ runner.temp }}/vcpkg-cache/
   cache-key:
-    description: suffix for computed cache key
-    required: false
+    description: cache key
 
 runs:
   using: 'composite'
   steps:
-    # create cache directory and key
+    # create cache directory
     - name: mkdir
       id: cache-directory
       run: |
@@ -20,9 +19,6 @@ runs:
 
         CACHE_DIR=$(realpath "${INPUT_DIRECTORY}")
         echo "path=${CACHE_DIR}" >> "${GITHUB_OUTPUT}"
-
-        CACHE_DIR_HASH=$(echo "${CACHE_DIR}" | sha256sum)
-        echo "hash=${CACHE_DIR_HASH%% *}" >> "${GITHUB_OUTPUT}"
       shell: bash
       env:
         INPUT_DIRECTORY: ${{ inputs.directory }}
@@ -40,6 +36,6 @@ runs:
     - name: setup actions/cache
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
-        key: vcpkg-${{ github.job }}-${{ runner.os }}-${{ steps.cache-directory.outputs.hash }}${{ inputs.cache-key }}
+        key: ${{ inputs.cache-key }}
         path: ${{ steps.cache-directory.outputs.path }}
         # should have inputs for: lookup-only

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,11 +43,6 @@ jobs:
       - if: ${{ runner.os == 'Windows' }}
         run: echo "VCPKG_BINARY_SOURCES=clear" >> "${GITHUB_ENV}"
 
-      - if: ${{ runner.os == 'Windows' }}
-        uses: ./.github/actions/vcpkg-files-cache
-        with:
-          cache-key: ${{ matrix.libmagic-linkage }}
-
       - id: setup-libmagic
         uses: ./.github/actions/setup-libmagic
         with:
@@ -108,7 +103,18 @@ jobs:
 
       # disable vcpkg default binary cache
       - run: echo "VCPKG_BINARY_SOURCES=clear" >> "${GITHUB_ENV}"
+
+      - id: cache-key
+        if: ${{ runner.os == 'Windows' }}
+        run: |
+          vcpkg_rev=$(cargo metadata --format-version 1 --no-deps | jq --raw-output '.packages[] | select(.name == "magic-sys").metadata.vcpkg.rev')
+          cache_key="cargo-vcpkg-${vcpkg_rev}-windows-libmagic+pkgconf"
+
+          echo "key=${cache_key}" >> "${GITHUB_OUTPUT}"
+
       - uses: ./.github/actions/vcpkg-files-cache
+        with:
+          cache-key: ${{ steps.cache-key.outputs.key }}
 
       - run: cargo --verbose --version
 


### PR DESCRIPTION
Fixes #112 

Cache key should implicitly include the actual packages being installed, e.g.
- `libmagic:x64-windows-static-md`
- `libmagic:x64-windows`
- `pkgconf:x64-windows`

But they are hardcoded into the action / workflow without user inputs. If that changes, just apply a "-v2" suffix or such.