### PR TITLE
Add CI release workflow using `release-plz`

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,88 @@
+name: release-plz
+
+permissions: {}
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-plz-release:
+    name: "release-plz release"
+    runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+    environment:
+      name: crates.io
+      url: https://crates.io/crates/magic-sys
+    steps:
+      - uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
+      - id: generate-token
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          persist-credentials: true
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # doesn't have usual versioned releases/tags
+        with:
+          toolchain: "1.88.0" # current pinned stable
+
+      - id: auth
+        uses: rust-lang/crates-io-auth-action@e919bc7605cde86df457cf5b93c5e103838bd879 # v1.0.1
+
+      - uses: release-plz/action@ccf6dd998441f26020f4315f1ebe95d9e2e42600 # v0.5.110
+        with:
+          command: release
+          version: "0.3.139"
+          verbose: true
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+  release-plz-pr:
+    name: "release-plz pr"
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
+      - id: generate-token
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          persist-credentials: true
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # doesn't have usual versioned releases/tags
+        with:
+          toolchain: "1.88.0" # current pinned stable
+
+      - uses: release-plz/action@ccf6dd998441f26020f4315f1ebe95d9e2e42600 # v0.5.110
+        with:
+          command: release-pr
+          version: "0.3.139"
+          verbose: true
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
The actual release part should be tested with a pre-release version, after having a proper `CHANGELOG`, so possibly follow-up