### PR TITLE
Setup libmagic for `release-plz release` CI

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -38,6 +38,8 @@ jobs:
         with:
           toolchain: "1.88.0" # current pinned stable
 
+      - uses: ./.github/actions/setup-libmagic
+
       - id: auth
         uses: rust-lang/crates-io-auth-action@e919bc7605cde86df457cf5b93c5e103838bd879 # v1.0.1
 


### PR DESCRIPTION
See https://github.com/robo9k/rust-magic-sys/issues/120#issuecomment-3133136845

Altermatively could use `DOCS_RS` fake build or disable `cargo`'s verification