### PR TITLE
Fix crate `license` SPDX expression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = [
     "no-std",
 ]
 repository = "https://github.com/robo9k/rust-magic-sys.git"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 version = "0.4.0-alpha.1"
 authors = ["robo9k <robo9k@symlink.io>"]
 links = "magic"


### PR DESCRIPTION
`license` must be a valid SPDX expression.
This does not change the crate license.