### PR TITLE
release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.4.0-alpha.2](https://github.com/robo9k/rust-magic-sys/compare/v0.4.0-alpha.1...v0.4.0-alpha.2) - 2025-07-29
-
-### Fixed
-
-- Only `include` required files in .crate
-
-### Other
-
-- Fix crate `license` SPDX expression
-
-## [0.4.0-alpha.1](https://github.com/robo9k/rust-magic-sys/compare/v0.3.0...v0.4.0-alpha.1) - 2025-07-28
+## [0.4.0](https://github.com/robo9k/rust-magic-sys/compare/v0.3.0...v0.4.0) - 2025-07-31
 
 This version adds `pkg-config` as an alternative default feature to the existing `vcpkg` build. The `vcpkg` build is now an optional default feature.  
 The optional dependency on `pkg-config` bumps the build requirement on the `libmagic` C library to version 5.39 (from 2020-06-14) or newer.  
@@ -38,9 +28,11 @@ The minimum supported Rust version (MSRV) is now 1.64
 ### Fixed
 
 - [**breaking**] Fix C type of `buffer` param in `magic_buffer`
+- Only `include` required files in .crate
 
 ### Other
 
 - Bump MSRV to 1.64
 - Replace `libc` crate dependency with `core::ffi`
 - Update pinned revision for `cargo-vcpkg`
+- Fix crate `license` SPDX expression

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "magic-sys"
-version = "0.4.0-alpha.2"
+version = "0.4.0"
 dependencies = [
  "pkg-config",
  "vcpkg",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 ]
 repository = "https://github.com/robo9k/rust-magic-sys.git"
 license = "MIT OR Apache-2.0"
-version = "0.4.0-alpha.2"
+version = "0.4.0"
 authors = ["robo9k <robo9k@symlink.io>"]
 links = "magic"
 include = [

--- a/systest/Cargo.lock
+++ b/systest/Cargo.lock
@@ -152,7 +152,7 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "magic-sys"
-version = "0.4.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "pkg-config",
  "vcpkg",


### PR DESCRIPTION
This is the combination of pre-releases `0.4.0-alpha.1` and `0.4.0-alpha.2` into one release `0.4.0`

Closes #120 